### PR TITLE
Validate values in available_on.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -128,7 +128,7 @@ properties:
     available_on:
       class:
       - Book
-      - Compound Object
+      - CompoundObject
     cardinality:
       minimum: 0
     controlled_values:
@@ -504,7 +504,7 @@ properties:
     available_on:
       class:
       - Book
-      - Compound Object
+      - CompoundObject
       - Image
       - Pdf
     cardinality:
@@ -3880,7 +3880,7 @@ properties:
     available_on:
       class:
       - Book
-      - Compound Object
+      - CompoundObject
     cardinality:
       minimum: 0
     controlled_values:
@@ -4090,7 +4090,7 @@ properties:
     available_on:
       class:
       - Book
-      - Compound Object
+      - CompoundObject
       - Image
       - Pdf
     cardinality:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -3744,7 +3744,13 @@ properties:
   table_of_contents:
     available_on:
       class:
-      - AllButImage
+      - GenericWork
+      - Video
+      - Audio
+      - Pdf
+      - Book
+      - CompoundObject
+      - Newspaper
     cardinality:
       maximum: 1
       minimum: 0

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -3056,7 +3056,14 @@ properties:
   provider:
     available_on:
       class:
-      - ''
+      - GenericWork
+      - Image
+      - Video
+      - Audio
+      - Pdf
+      - Book
+      - CompoundObject
+      - Newspaper
     cardinality:
       maximum: 1
       minimum: 1

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -56,7 +56,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -94,7 +94,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -163,7 +163,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -233,7 +233,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -268,7 +268,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -343,7 +343,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -383,7 +383,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -424,7 +424,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -463,7 +463,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -506,7 +506,7 @@ properties:
       - Book
       - Compound Object
       - Image
-      - PDF
+      - Pdf
     cardinality:
       minimum: 0
     controlled_values:
@@ -541,7 +541,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -726,7 +726,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -764,7 +764,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -804,7 +804,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -844,7 +844,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -883,7 +883,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -924,7 +924,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -953,7 +953,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -994,7 +994,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1032,7 +1032,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1071,7 +1071,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1111,7 +1111,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1146,7 +1146,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1181,7 +1181,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1215,7 +1215,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1250,7 +1250,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1283,7 +1283,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1316,7 +1316,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1354,7 +1354,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1393,7 +1393,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1432,7 +1432,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1470,7 +1470,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1539,7 +1539,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1578,7 +1578,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1618,7 +1618,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1657,7 +1657,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1717,7 +1717,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1748,7 +1748,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1784,7 +1784,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1822,7 +1822,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1861,7 +1861,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1900,7 +1900,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -1941,7 +1941,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2008,7 +2008,7 @@ properties:
     available_on:
       class:
       - Book
-      - PDF
+      - Pdf
     cardinality:
       minimum: 0
     controlled_values:
@@ -2039,7 +2039,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2076,7 +2076,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2117,7 +2117,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2156,7 +2156,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2191,7 +2191,7 @@ properties:
     available_on:
       class:
       - Book
-      - PDF
+      - Pdf
     cardinality:
       maximum: 1
       minimum: 0
@@ -2224,7 +2224,7 @@ properties:
       class:
       - Book
       - Newspaper
-      - PDF
+      - Pdf
     cardinality:
       maximum: 1
       minimum: 0
@@ -2259,7 +2259,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2297,7 +2297,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2334,7 +2334,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2370,7 +2370,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2408,7 +2408,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2448,7 +2448,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2486,7 +2486,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2525,7 +2525,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2563,7 +2563,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2602,7 +2602,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2636,7 +2636,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2672,7 +2672,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2710,7 +2710,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2750,7 +2750,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2785,7 +2785,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2823,7 +2823,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2864,7 +2864,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2903,7 +2903,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2942,7 +2942,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -2980,7 +2980,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3021,7 +3021,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3086,7 +3086,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3119,7 +3119,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3157,7 +3157,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3187,7 +3187,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3221,7 +3221,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3257,7 +3257,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3297,7 +3297,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3334,7 +3334,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3374,7 +3374,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3403,7 +3403,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3442,7 +3442,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3476,7 +3476,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3507,7 +3507,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3545,7 +3545,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3583,7 +3583,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3622,7 +3622,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3660,7 +3660,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3702,7 +3702,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3773,7 +3773,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3807,7 +3807,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3844,7 +3844,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3963,7 +3963,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -3996,7 +3996,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4028,7 +4028,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4060,7 +4060,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4092,7 +4092,7 @@ properties:
       - Book
       - Compound Object
       - Image
-      - PDF
+      - Pdf
     cardinality:
       minimum: 0
     controlled_values:
@@ -4223,7 +4223,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4255,7 +4255,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4287,7 +4287,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4320,7 +4320,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4352,7 +4352,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4384,7 +4384,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4416,7 +4416,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4448,7 +4448,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4480,7 +4480,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4513,7 +4513,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4545,7 +4545,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4577,7 +4577,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4610,7 +4610,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4642,7 +4642,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4674,7 +4674,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4706,7 +4706,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4738,7 +4738,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4771,7 +4771,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4803,7 +4803,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4835,7 +4835,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4867,7 +4867,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4900,7 +4900,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4932,7 +4932,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4965,7 +4965,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -4997,7 +4997,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5029,7 +5029,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5062,7 +5062,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5095,7 +5095,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5127,7 +5127,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5159,7 +5159,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5191,7 +5191,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5223,7 +5223,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5255,7 +5255,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5288,7 +5288,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5321,7 +5321,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5351,7 +5351,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5383,7 +5383,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5415,7 +5415,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5447,7 +5447,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5479,7 +5479,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5511,7 +5511,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5543,7 +5543,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5575,7 +5575,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5607,7 +5607,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5639,7 +5639,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5671,7 +5671,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5703,7 +5703,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5735,7 +5735,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5767,7 +5767,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5799,7 +5799,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5832,7 +5832,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5864,7 +5864,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper
@@ -5905,7 +5905,7 @@ properties:
       - Image
       - Video
       - Audio
-      - PDF
+      - Pdf
       - Book
       - CompoundObject
       - Newspaper

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -55,7 +55,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -94,7 +93,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -164,7 +162,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -235,7 +232,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -271,7 +267,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -347,7 +342,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -388,7 +382,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -430,7 +423,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -470,7 +462,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -549,7 +540,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -735,7 +725,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -774,7 +763,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -815,7 +803,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -856,7 +843,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -896,7 +882,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -938,7 +923,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -968,7 +952,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1010,7 +993,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1049,7 +1031,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1089,7 +1070,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1130,7 +1110,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1166,7 +1145,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1202,7 +1180,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1237,7 +1214,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1273,7 +1249,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1307,7 +1282,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1341,7 +1315,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1380,7 +1353,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1420,7 +1392,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1460,7 +1431,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1499,7 +1469,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1569,7 +1538,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1609,7 +1577,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1650,7 +1617,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1690,7 +1656,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1751,7 +1716,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1783,7 +1747,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1820,7 +1783,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1859,7 +1821,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1899,7 +1860,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1939,7 +1899,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -1981,7 +1940,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2080,7 +2038,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2118,7 +2075,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2160,7 +2116,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2200,7 +2155,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2304,7 +2258,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2343,7 +2296,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2381,7 +2333,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2418,7 +2369,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2457,7 +2407,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2498,7 +2447,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2537,7 +2485,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2577,7 +2524,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2616,7 +2562,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2656,7 +2601,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2691,7 +2635,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2728,7 +2671,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2767,7 +2709,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2808,7 +2749,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2844,7 +2784,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2883,7 +2822,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2925,7 +2863,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -2965,7 +2902,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3005,7 +2941,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3044,7 +2979,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3086,7 +3020,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3152,7 +3085,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3186,7 +3118,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3225,7 +3156,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3256,7 +3186,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3291,7 +3220,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3328,7 +3256,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3369,7 +3296,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3407,7 +3333,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3448,7 +3373,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3478,7 +3402,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3518,7 +3441,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3553,7 +3475,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3585,7 +3506,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3624,7 +3544,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3663,7 +3582,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3703,7 +3621,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3742,7 +3659,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3785,7 +3701,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3857,7 +3772,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3892,7 +3806,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -3930,7 +3843,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4050,7 +3962,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4084,7 +3995,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4117,7 +4027,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4150,7 +4059,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4314,7 +4222,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4347,7 +4254,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4380,7 +4286,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4414,7 +4319,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4447,7 +4351,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4480,7 +4383,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4513,7 +4415,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4546,7 +4447,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4579,7 +4479,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4613,7 +4512,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4646,7 +4544,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4679,7 +4576,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4713,7 +4609,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4746,7 +4641,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4779,7 +4673,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4812,7 +4705,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4845,7 +4737,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4879,7 +4770,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4912,7 +4802,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4945,7 +4834,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -4978,7 +4866,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5012,7 +4899,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5045,7 +4931,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5079,7 +4964,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5112,7 +4996,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5145,7 +5028,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5179,7 +5061,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5213,7 +5094,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5246,7 +5126,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5279,7 +5158,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5312,7 +5190,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5345,7 +5222,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5378,7 +5254,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5412,7 +5287,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5446,7 +5320,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5477,7 +5350,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5510,7 +5382,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5543,7 +5414,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5576,7 +5446,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5609,7 +5478,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5642,7 +5510,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5675,7 +5542,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5708,7 +5574,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5741,7 +5606,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5774,7 +5638,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5807,7 +5670,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5840,7 +5702,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5873,7 +5734,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5906,7 +5766,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5939,7 +5798,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -5973,7 +5831,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -6006,7 +5863,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book
@@ -6048,7 +5904,6 @@ properties:
       - GenericWork
       - Image
       - Video
-      - Collection
       - Audio
       - PDF
       - Book

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -9,7 +9,9 @@ class AdditionalChecks:
         self.path = m3
         self.m3 = yaml.safe_load(open(m3))
         self.unique_classes = self.find_unique_classes()
+        self.all_exceptions = []
         self.validate_available_on()
+        self.raise_exceptions()
 
     def find_unique_classes(self):
         return [work_type for work_type in self.m3['classes']]
@@ -18,7 +20,14 @@ class AdditionalChecks:
         for property in self.m3['properties']:
             for work_type in self.m3['properties'][property]['available_on']['class']:
                 if work_type not in self.unique_classes:
-                    raise ValueError(f'Unknown worktype {work_type} in {property} in {self.path}.')
+                    self.all_exceptions.append(f'Unknown worktype {work_type} in {property} in {self.path}.')
+
+    def raise_exceptions(self):
+        separator = '\n'
+        if len(self.all_exceptions) > 0:
+            raise Exception(f'{self.path} not valid. Has at least {len(self.all_exceptions)} errors including:\n\n{separator.join(self.all_exceptions)}')
+        else:
+            pass
 
 
 schema = json.load(open('schemas/schema.json'))

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -4,8 +4,26 @@ import yaml
 import os
 
 
+class AdditionalChecks:
+    def __init__(self, m3):
+        self.path = m3
+        self.m3 = yaml.safe_load(open(m3))
+        self.unique_classes = self.find_unique_classes()
+        self.validate_available_on()
+
+    def find_unique_classes(self):
+        return [work_type for work_type in self.m3['classes']]
+
+    def validate_available_on(self):
+        for property in self.m3['properties']:
+            for work_type in self.m3['properties'][property]['available_on']['class']:
+                if work_type not in self.unique_classes:
+                    raise ValueError(f'Unknown worktype {work_type} in {property} in {self.path}.')
+
+
 schema = json.load(open('schemas/schema.json'))
 for path, directories, files in os.walk('maps'):
     for file in files:
         current_map = yaml.safe_load(open(f'maps/{file}'))
         validate(current_map, schema=schema)
+        check = AdditionalChecks(f'maps/{file}')

--- a/utilities/write_m3.py
+++ b/utilities/write_m3.py
@@ -127,7 +127,7 @@ class RDFProperty:
 
     @staticmethod
     def __get_classes(data):
-        types = ("GenericWork", "Image", "Video", "Collection", "Audio", "PDF", "Book", "CompoundObject", "Newspaper")
+        types = ("GenericWork", "Image", "Video", "Audio", "PDF", "Book", "CompoundObject", "Newspaper")
         available_on = []
         for value in data.split(','):
             if value == "All":

--- a/utilities/write_m3.py
+++ b/utilities/write_m3.py
@@ -127,7 +127,7 @@ class RDFProperty:
 
     @staticmethod
     def __get_classes(data):
-        types = ("GenericWork", "Image", "Video", "Audio", "PDF", "Book", "CompoundObject", "Newspaper")
+        types = ("GenericWork", "Image", "Video", "Audio", "Pdf", "Book", "CompoundObject", "Newspaper")
         available_on = []
         for value in data.split(','):
             if value == "All":


### PR DESCRIPTION
## What Does This Do?

1. Expands checks beyond the schema defined in Houndstooth to also check that the values found in `available_on` are actually defined in the profile.
2. Removes `Collection` from m3 since it's not a work type.
3. Corrects all uses of `Pdf` to match how the work type is spelled according to Hyku and Rails conventions.
4. Corrects bad instances of `CompoundObject` that were inherited from he spreadsheet.
5. Defines `available_on` for `provider` since it's not in the spreadsheet it initially inherited from.
6. Converts `AllButImage` to individual work types based on types defined here.
7. Corrects initial script that dereferenced Google Sheet just in case.

## Does this ensure that our m3 profile is now "valid"?

Not necessarily.  It validates it according to the schema defined in Houndstooth and ensures that `available_on` is aligned with prescribed work types.  Errors that are beyond the schema and this could persist.

## What's next

After this is approved, we can upload to our test instance to make sure it functions with no errors.  If additional errors occur, we can expand validity checks here.