### PR TITLE
Check for multi_value property.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -6,7 +6,7 @@
 m3_version: 1.0.beta2
 
 profile:
-  date_modified: '2022-11-10'
+  date_modified: '2022-11-12'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
   type: Ensure multi-values

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -9,8 +9,8 @@ profile:
   date_modified: '2022-11-10'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: no more collections
-  version: 15.0
+  type: Ensure multi-values
+  version: 16.0
 
 classes:
   Attachment:
@@ -275,6 +275,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 1
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
       sources:
@@ -3037,6 +3038,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 1
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -3172,6 +3174,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 1
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
       sources:
@@ -3281,6 +3284,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 1
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
       sources:
@@ -6072,6 +6076,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 1
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6141,6 +6146,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 1
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#integer
       sources:
@@ -6165,6 +6171,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 1
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#integer
       sources:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -3291,7 +3291,6 @@ properties:
       default: Rights Statement
     index_documentation: displayable, searchable, rights facet
     indexing:
-    - admin_only
     - displayable
     - stored_searchable
     - facetable

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -11,6 +11,7 @@ class AdditionalChecks:
         self.unique_classes = self.find_unique_classes()
         self.all_exceptions = []
         self.validate_available_on()
+        self.check_for_maximum_one()
         self.raise_exceptions()
 
     def find_unique_classes(self):
@@ -21,6 +22,13 @@ class AdditionalChecks:
             for work_type in self.m3['properties'][property]['available_on']['class']:
                 if work_type not in self.unique_classes:
                     self.all_exceptions.append(f'Unknown worktype {work_type} in {property} in {self.path}.')
+
+    def check_for_maximum_one(self):
+        for property, value in self.m3['properties'].items():
+            if 'maximum' in value['cardinality'] and 'minimum' in value['cardinality']:
+                if value['cardinality']['maximum'] == 1 and value['cardinality']['minimum'] == 1:
+                    if 'multi_value' not in value:
+                        self.all_exceptions.append(f'{property} has obligation 1 but no multi_value property in {self.path}.')
 
     def raise_exceptions(self):
         separator = '\n'


### PR DESCRIPTION
## What Does This Do

Adds validation check for properties with an obligation of `1`  to ensure a `multi_value: true`.

## Why?

Properties from Hyrax's base_metadata properties assume that properties like this are string instead of an array and causes the application to break.  By having this check and following this practice, we ensure that this bug should not cause app failures like we're getting now.

 