### PR TITLE
Usage

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -68,7 +68,7 @@ properties:
       sources:
       - 'null'
     definition:
-      default: Enter a summary of the resource. End this field with a period.
+      default: Summary of the resource.
     display_label:
       default: Abstract
     index_documentation: displayable, searchable
@@ -87,6 +87,8 @@ properties:
     - Prosecutor John Keker gives his closing statement to the jury, explaining Col.
       John North's involvement in the Iran-Contra affair even though the majority
       of his statement is censored due to classified information.
+    usage_guidelines:
+      default: Enter a summary of the resource. End this field with a period.
   acquisition_identifier:
     available_on:
       class:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -108,8 +108,7 @@ properties:
       sources:
       - 'null'
     definition:
-      default: Enter an identifier assigned by a museum for acquisition. Values typically
-        start with a year (e.g. 1996.10.1)
+      default: An identifier assigned by a museum during acquisition.
     display_label:
       default: Acquisition Identifier
     index_documentation: displayable, searchable
@@ -126,6 +125,9 @@ properties:
     requirement: optional
     sample_values:
     - 1996.10.1
+    usage_guidelines:
+      default: Enter an identifier assigned by a museum for acquisition. Values typically
+        start with a year (e.g. 1996.10.1)
   addressee:
     available_on:
       class:


### PR DESCRIPTION
## What's new?

This PR adds usage_guidelines to the `abstract` and `acquisition_identifier` properties. Currently we are not seeing any usage guidelines or definitions on the metadata form. This PR is intended to check and see if adding usage_guidelines makes the specific text in UTK's M3 profile appear on the form (not the basic metadata text). Edits were made to both `abstract` and `acquisition_identifier` to see if the appearance of usage_guidelines values is different based on whether the property is associated with basic metadata or not.

## How should this be tested?

Check and see if the specific text in our M3 appears in the form. If it doesn't, we'll need to ask Softserv additional questions to see how we can include entry instructions.