### PR TITLE
Modify things based on Shana's feedback.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -6,11 +6,11 @@
 m3_version: 1.0.beta2
 
 profile:
-  date_modified: '2022-11-12'
+  date_modified: '2022-11-15'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: Ensure multi-values
-  version: 19.0
+  type: Maximum 1 should always be an array
+  version: 20.0
 
 classes:
   Attachment:
@@ -101,6 +101,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -238,6 +239,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -275,6 +277,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
       sources:
@@ -597,6 +600,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -1103,6 +1107,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -1138,6 +1143,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#date
       sources:
@@ -1173,6 +1179,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -1207,6 +1214,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#date
       sources:
@@ -1242,6 +1250,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -1489,6 +1498,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -1671,6 +1681,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -1960,6 +1971,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -2031,6 +2043,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -2144,6 +2157,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
       sources:
@@ -2176,6 +2190,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2000/01/rdf-schema#Literal
       sources:
@@ -2209,6 +2224,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2000/01/rdf-schema#Literal
       sources:
@@ -2362,6 +2378,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
       sources:
@@ -2624,6 +2641,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2000/01/rdf-schema#Literal
       sources:
@@ -3143,6 +3161,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -3735,6 +3754,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -5958,6 +5978,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -5982,6 +6003,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6005,6 +6027,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6027,6 +6050,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6051,6 +6075,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6101,6 +6126,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6123,6 +6149,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6195,6 +6222,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -6243,6 +6271,7 @@ properties:
     cardinality:
       maximum: 1
       minimum: 0
+    multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#integer
       sources:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -10,7 +10,7 @@ profile:
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
   type: Maximum 1 should always be an array
-  version: 20.1
+  version: 21
 
 classes:
   Attachment:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -10,7 +10,7 @@ profile:
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
   type: Ensure multi-values
-  version: 16.0
+  version: 19.0
 
 classes:
   Attachment:
@@ -3172,7 +3172,7 @@ properties:
       - Newspaper
     cardinality:
       maximum: 1
-      minimum: 1
+      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
@@ -6144,7 +6144,7 @@ properties:
       - Attachment
     cardinality:
       maximum: 1
-      minimum: 1
+      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#integer
@@ -6169,7 +6169,7 @@ properties:
       - Attachment
     cardinality:
       maximum: 1
-      minimum: 1
+      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#integer
@@ -6210,7 +6210,7 @@ properties:
     property_uri: http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#hashValue
     range: http://www.w3.org/2001/XMLSchema#string
     requirement: optional
-  utk_type:
+  rdf_type:
     available_on:
       class:
       - Attachment

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -10,7 +10,7 @@ profile:
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
   type: Maximum 1 should always be an array
-  version: 20.0
+  version: 20.1
 
 classes:
   Attachment:

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -26,19 +26,19 @@ class AdditionalChecks:
 
     def check_for_maximum_one(self):
         for property, value in self.m3['properties'].items():
-            if 'maximum' in value['cardinality'] and 'minimum' in value['cardinality']:
-                if value['cardinality']['maximum'] == 1 and value['cardinality']['minimum'] == 1:
+            if 'maximum' in value['cardinality']:
+                if value['cardinality']['maximum'] == 1:
                     if 'multi_value' not in value:
                         self.all_exceptions.append(f'{property} has obligation 1 but no multi_value property in {self.path}.')
 
     def check_for_excess_multi_values(self):
         for property, value in self.m3['properties'].items():
             if 'multi_value' in value:
-                if 'maximum' not in value['cardinality'] or 'minimum' not in value['cardinality']:
+                if 'maximum' not in value['cardinality']:
                     self.all_exceptions.append(
-                        f'{property} has multi_value property but missing maximum and / or minimum property(s).'
+                        f'{property} has multi_value property but missing maximum minimum property.'
                     )
-                elif value['cardinality']['maximum'] != 1 or value['cardinality']['minimum'] != 1:
+                elif value['cardinality']['maximum'] != 1:
                     self.all_exceptions.append(
                         f'{property} has multi_value property but cardinality is not 1.'
                     )

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -36,11 +36,11 @@ class AdditionalChecks:
             if 'multi_value' in value:
                 if 'maximum' not in value['cardinality']:
                     self.all_exceptions.append(
-                        f'{property} has multi_value property but missing maximum minimum property.'
+                        f'{property} has multi_value property but missing maximum property.'
                     )
                 elif value['cardinality']['maximum'] != 1:
                     self.all_exceptions.append(
-                        f'{property} has multi_value property but cardinality is not 1.'
+                        f'{property} has multi_value property but cardinality is not a maximum of 1.'
                     )
 
     def raise_exceptions(self):


### PR DESCRIPTION
## What Does This Do

1. Makes `resource_link` no longer required.
2. Changes the property name of `utk_type` back to `rdf_type`
3. Changes validation rules to be based on whether or not a property ever has a maximum of 1.
4. Updates all properties with a maximum of 1 to have `multi_value` properties.

## Why?

1. You can't use the form right now to upload works because `resource_link` is required.
2. `rdf_type` is hardcoded for viewer things (`pcdmuse:PreservationFile` / `pcdmuse:IntermediateFile`).