### PR TITLE
Add title on attachment.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -3831,6 +3831,7 @@ properties:
       - Book
       - CompoundObject
       - Newspaper
+      - Attachment
     cardinality:
       maximum: 1
       minimum: 1


### PR DESCRIPTION
## What Does This Do

Allows titles on Attachments.

## Why?

Attachments have labels / titles but currently it's not valid to have these on a bulkrax sheet.