### PR TITLE
Add call_number on Image.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -9,8 +9,8 @@ profile:
   date_modified: '2022-11-15'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v27 -- Duration on Attachment
-  version: 27
+  type: UTK Digital Collections v28 -- Call Number Allowed on Image
+  version: 28
 
 classes:
   Attachment:
@@ -601,6 +601,7 @@ properties:
     available_on:
       class:
       - Book
+      - Image
     cardinality:
       maximum: 1
       minimum: 0


### PR DESCRIPTION
## What Does This Do?

Allows `call_number` on Image to address these problems:

```
call_number is not available on Image for volvoices:1994.
call_number is not available on Image for volvoices:1998.
call_number is not available on Image for volvoices:1991.
call_number is not available on Image for volvoices:2003.
call_number is not available on Image for volvoices:2001.
call_number is not available on Image for volvoices:1992.
call_number is not available on Image for volvoices:1997.
call_number is not available on Image for volvoices:1995.
call_number is not available on Image for volvoices:1993.
call_number is not available on Image for volvoices:2000.
call_number is not available on Image for volvoices:1996.
call_number is not available on Image for volvoices:2002.

```