### PR TITLE
Require file types.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -9,8 +9,8 @@ profile:
   date_modified: '2022-11-15'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v28 -- Call Number Allowed on Image
-  version: 28
+  type: UTK Digital Collections v29 -- Types on Files
+  version: 29
 
 classes:
   Attachment:
@@ -6283,7 +6283,7 @@ properties:
       class:
       - Attachment
     cardinality:
-      minimum: 0
+      minimum: 1
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#anyURI
       sources:
@@ -6300,7 +6300,7 @@ properties:
     mappings: {}
     property_uri: https://ontology.lib.utk.edu/works#hasType
     range: http://www.w3.org/2001/XMLSchema#anyURI
-    requirement: optional
+    requirement: required
     sample_values:
     - http://pcdm.org/use#PreservationFile
     - http://pcdm.org/use#IntermediateFile


### PR DESCRIPTION
## What Does This Do

This makes `rdf_type` a required property on Attachments.  

## Why

`rdf_type` often explains what a file is and is sometimes used to trigger when something should happen to a file (derivative generation, pass to a viewer, etc.). Without this being required, it's easy to add somehting via the gui and not have derivative generation fire.