### PR TITLE
File language

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -6147,7 +6147,7 @@ properties:
       - 'null'
     definition:
       default: The language associated with a specific file or fileset. If present, should be none
-        or combination of subtag and prefix defined in the iana registry 
+        or combination of subtag and prefix defined in the iana registry
         (https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
         Must be present for files that correlate to IIIF manifests like caption / subtitle
         files.

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -9,8 +9,8 @@ profile:
   date_modified: '2022-11-15'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v29 -- Types on Files
-  version: 29
+  type: UTK Digital Collections v30 -- File Language Not Required
+  version: 30
 
 classes:
   Attachment:
@@ -6139,14 +6139,16 @@ properties:
       - Attachment
     cardinality:
       maximum: 1
-      minimum: 1
+      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
       - 'null'
     definition:
-      default: The language associated with a specific file or fileset.
+      default: The language associated with a specific file or fileset. If present, should be none
+        or combination of subtag and prefix defined in the iana registry 
+        (https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
     display_label:
       default: Language
     index_documentation: displayable
@@ -6157,7 +6159,10 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     requirement: optional
     sample_values:
-    - https://gist.github.com/markpbaggett/763205cd38d382eff3d0db20a265fe0e
+    - none
+    - en
+    - es
+    - en-CA-newfound
     syntax: BCP-47
   file_size:
     available_on:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -6149,6 +6149,8 @@ properties:
       default: The language associated with a specific file or fileset. If present, should be none
         or combination of subtag and prefix defined in the iana registry 
         (https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
+        Must be present for files that correlate to IIIF manifests like caption / subtitle
+        files.
     display_label:
       default: Language
     index_documentation: displayable


### PR DESCRIPTION
## What Does this Do

Makes `file_language` no longer required.

## Why

Right now, all attachments expect a `file_language` although the only use case where this is clearly important is closed captioning / subtitle files.