### PR TITLE
Language local

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -6,11 +6,11 @@
 m3_version: 1.0.beta2
 
 profile:
-  date_modified: '2023-05-04'
+  date_modified: '2023-07-19'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v34 - Add Local Languages and Remove Local from Display Labels
-  version: 34
+  type: UTK Digital Collections v35 - Alter Local Language Property
+  version: 35
 
 classes:
   Attachment:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -2390,7 +2390,7 @@ properties:
       sources:
       - iso639-2b
     definition:
-      default: Enter a language used in the resource. When multiple languages
+      default: Enter a language used in the resource as text. When multiple languages
         are present, use multiple fields. If no language is present, use "No
         linguistic content."
     display_label:
@@ -2405,11 +2405,11 @@ properties:
       mods_oai_pmh: mods:language/mods:languageTerm
       qualified_dc_pmh: dcterms:language
       simple_dc_pmh: dc:language
-    property_uri: http://purl.org/dc/terms/language
+    property_uri: http://dbpedia.org/ontology/language
     range: http://www.w3.org/2001/XMLSchema#string
     requirement: optional
     sample_values:
-    - http://id.loc.gov/vocabulary/iso639-2/eng
+    - English
   license:
     available_on:
       class:


### PR DESCRIPTION
## What does this Pull Request do?

This PR makes it so that the properties "language" and "language_local" have different property URIs. The dbo:language (http://dbpedia.org/ontology/language) was selected.

## How should this be tested?

Review property URI in RDF inquisitor. If the URI is not appropriate say why or suggest another. Check that this URI is not used elsewhere in the M3.

## Comments

I also looked at http://www.europeana.eu/schemas/edm/language but I wasn't sure the definition was a good fit ("The value for this element is added by the Data Ingestion Team as part of the ingestion process, based on the language of the data provider").

## Interested parties

@markpbaggett 
