### PR TITLE
Fix Sequence Spacing

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -3471,9 +3471,9 @@ properties:
       minimum: 0
     multi_value: true
     controlled_values:
-    format: http://www.w3.org/2001/XMLSchema#integer
-    sources:
-    - 'null'
+      format: http://www.w3.org/2001/XMLSchema#integer
+      sources:
+      - 'null'
     definition:
       default: Numeric order in which to display pages or other items
     display_label:


### PR DESCRIPTION
format and sources are children of controlled_values. We lost that somehow and that was ultimately causing the parse error.

finally got out the line by line debugger to find it