### PR TITLE
Change label for spatial_local also!

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -3655,7 +3655,7 @@ properties:
     definition:
       default: Enter the uncontrolled name of a place with which the resource is associated.
     display_label:
-      default: Spatial Coverage
+      default: Location
     indexing:
     - displayable
     - stored_searchable

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -10,7 +10,7 @@ profile:
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
   type: UTK Digital Collections v40 - Change "Spatial Coverage" label to "Location"
-  version: 40
+  version: 40.5
 
 classes:
   Attachment:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -10,7 +10,7 @@ profile:
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
   type: UTK Digital Collections v40 - Change "Spatial Coverage" label to "Location"
-  version: 40.5
+  version: 41
 
 classes:
   Attachment:


### PR DESCRIPTION
## What does this PR do?

This also changes the label for our spatial_local property (in addition to spatial). Since we have geographic values without URIs, we have two properties for the same content (differentiated by their form - string or URI). I neglected to address this earlier. Throughout our M3 we are using the same label for the controlled and uncontrolled values (except for with the keyword and subject properties).

## How should this be tested?

Did I leave anything else out? Do all the checks for formatting pass?

