### PR TITLE
Add role terms (42)

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -6,11 +6,11 @@
 m3_version: 1.0.beta2
 
 profile:
-  date_modified: '2024-07-02'
+  date_modified: '2024-08-31'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v40 - Change "Spatial Coverage" label to "Location"
-  version: 41
+  type: UTK Digital Collections v42 - Add missing role terms
+  version: 42
 
 classes:
   Attachment:
@@ -4623,7 +4623,7 @@ properties:
     requirement: optional
     sample_values:
     - Manetti, Antonio
-  utk_costumer_designer:
+  utk_costume_designer:
     available_on:
       class:
       - GenericWork
@@ -5270,6 +5270,38 @@ properties:
     requirement: optional
     sample_values:
     - Manetti, Antonio
+  utk_minute_taker:
+    available_on:
+      class:
+      - GenericWork
+      - Image
+      - Video
+      - Audio
+      - Pdf
+      - Book
+      - CompoundObject
+      - Newspaper
+    cardinality:
+      minimum: 0
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Minute Taker
+    index_documentation: displayable, searchable
+    indexing:
+    - displayable
+    - stored_searchable
+    mappings:
+      mods_oai_pmh: mods:name[mods:role/mods:roleTerm[contains(.,'Minute taker')]]/mods:namePart
+      qualified_dc_pmh: dcterms:contributor
+      simple_dc_pmh: dc:contributor
+    property_uri: https://ontology.lib.utk.edu/roles#mtk
+    range: http://www.w3.org/2001/XMLSchema#string
+    requirement: optional
+    sample_values:
+    - Eaton, Andrew Chamberlain
   utk_music_copyist:
     available_on:
       class:

--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -9,7 +9,7 @@ profile:
   date_modified: '2024-08-31'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v40 - Change "Spatial Coverage" label to "Location"
+  type: UTK Digital Collections v42 - Add missing role terms
   version: 42
 
 classes:


### PR DESCRIPTION
## What does this Pull Request do?

Weston's ingests have returned errors in some cases. This PR addresses the errors that relate to the M3 profile specifically. Errors include:

- Error creating sheet utk_costume_designer is not listed in the m3 profile.
- Error validating sheet utk_minute_taker is not listed in the m3 profile.

## What's new?

This PR adds "utk_minute_taker" as a property. It addresses a typo on the existing "utk_costumer_designer" property.

## How should this be tested?

Ensure that automatic tests on spacing pass. Confirm that this PR addresses all current M3 issues we're aware of.

## Anything else?

It looks like I'll also need to update the utk ontology file so that https://ontology.lib.utk.edu/roles#mtk is present within it. I'll open a separate PR for this.
