### PR TITLE
Add Image class to addressee property.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -135,6 +135,7 @@ properties:
       - Book
       - CompoundObject
       - Pdf
+      - Image
     cardinality:
       minimum: 0
     controlled_values:


### PR DESCRIPTION
## What does this Pull Request do?

This PR adds Image to the addressee property to resolve migration issues ("addressee is not available on Image for galston:703"). Correspondence (postcards, letters, etc.) typically weren't represented using large images in Islandora, so the use of it in galston was not recognized during M3 creation.