### PR TITLE
Fix incorrect property URI (crp) for utk_addressee.

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -6,11 +6,11 @@
 m3_version: 1.0.beta2
 
 profile:
-  date_modified: '2024-09-10'
+  date_modified: '2025-02-14'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v44 - Add Image class to addressee property
-  version: 44
+  type: UTK Digital Collections v45 - Fix incorrect property URI (crp) for utk_addressee
+  version: 45
 
 classes:
   Attachment:
@@ -4081,7 +4081,7 @@ properties:
       mods_oai_pmh: mods:name[mods:role/mods:roleTerm[contains(.,'Addressee')]]/mods:namePart
       qualified_dc_pmh: dcterms:contributor
       simple_dc_pmh: dc:contributor
-    property_uri: https://ontology.lib.utk.edu/roles#crp
+    property_uri: https://ontology.lib.utk.edu/roles#rcp
     range: http://www.w3.org/2001/XMLSchema#string
     requirement: optional
     sample_values:


### PR DESCRIPTION
## What does this PR do?

The property_uri for utk_addressee was incorrectly listed as https://ontology.lib.utk.edu/roles#crp (Correspondent) instead of https://ontology.lib.utk.edu/roles#rcp (Addressee). This is making it so that two labels are showing up when import sheets have correspondents - e.g. https://digitalcollections.lib.utk.edu/concern/books/b4175bf2-f09f-43b9-9a4e-cdd9fabbb026 This PR edits the duplicate reference to roles#crp.

## How do I test this?

Ensure that the URIs are accurate for what is listed in the Roles ontology - https://ontology.lib.utk.edu/roles

## Other

Let me know if any action is needed to make the labels appear correctly beyond uploading the new edited M3 once this is merged.