### PR TITLE
Change blacklight to rights_statement_sim for license and rights_stat…

### DIFF
--- a/maps/utk.yml
+++ b/maps/utk.yml
@@ -9,8 +9,8 @@ profile:
   date_modified: '2025-04-02'
   responsibility: https://www.lib.utk.edu
   responsibility_statement: University of Tennessee Libraries
-  type: UTK Digital Collections v49 - Add Attachment as a class to descriptive metadata fields
-  version: 49
+  type: UTK Digital Collections v50 - Nest license and rights_statement under blacklight rights_statement_sim
+  version: 50
 
 classes:
   Attachment:
@@ -2498,9 +2498,8 @@ properties:
     indexing:
     - displayable
     - stored_searchable
-    - facetable
     mappings:
-      blacklight: rights_sim
+      blacklight: rights_statement_sim
       mods_oai_pmh: mods:accessCondition[@type="use and reproduction"]
       qualified_dc_pmh: dcterms:license
       simple_dc_pmh: dc:rights
@@ -3522,14 +3521,13 @@ properties:
     definition:
       default: Enter the rights statement that applies to the resource.
     display_label:
-      default: Rights Statement
+      default: Rights
     index_documentation: displayable, searchable, rights facet
     indexing:
     - displayable
     - stored_searchable
-    - facetable
     mappings:
-      blacklight: rights_sim
+      blacklight: rights_statement_sim
       mods_oai_pmh: mods:accessCondition[@type="use and reproduction"]
       qualified_dc_pmh: dcterms:rights
       simple_dc_pmh: dc:rights


### PR DESCRIPTION
…ement. Update label to Rights.

## What does this Pull Request do?

Kirk noticed that we had a blacklight field that didn't exist (rights_sim). This PR changes that field to rights_statement_sim and groups both license and rights statement values into one field (for a facet and at the item-level metadata). Rather than "Rights Statement", the label for this joint field has been changed to "Rights" so it more accurately represents both types of values (CC licenses and rights statements).

## How should this be tested?

Do rights statements and licenses appear in the same facet and in the same item-level metadata field? Is the label for both "Rights"?